### PR TITLE
Don't leak file descriptors

### DIFF
--- a/src/zensight/file_buffer/core.clj
+++ b/src/zensight/file_buffer/core.clj
@@ -15,7 +15,7 @@
   (max-size [segment] "Size or :unlimited")
   (read-bytes [buf-pos segment dst offset len] "Read into dst at offset and len")
   (write-bytes [buf-pos segment src offset len] "Write from src")
-  (free-storage [segment buf-pos] "Frees any storage resources"))
+  (free-storage [segment closed? buf-pos] "Frees any storage resources"))
 
 (defn readable-bytes
   [buf-pos max-size]
@@ -45,7 +45,7 @@
     (.write fos src offset len)
     len)
 
-  (free-storage [this buf-pos] nil))
+  (free-storage [this closed? buf-pos] nil))
 
 (defn file-segment
   [file]
@@ -75,7 +75,7 @@
       (System/arraycopy src offset @buffer (.write-count buf-pos) new-len)
       new-len))
 
-  (free-storage [this buf-pos] (reset! buffer nil)))
+  (free-storage [this closed? buf-pos] (reset! buffer nil)))
 
 (defn memory-segment
   [size]
@@ -166,7 +166,7 @@
                    src-len)))
         total-written)))
 
-  (free-storage [this buf-pos]
+  (free-storage [this closed? buf-pos]
     (loop [bufs buffers
            abs-buf-end 0]
       (when-let [b (first bufs)]
@@ -175,7 +175,7 @@
                       0)
               abs-buf-end (+ abs-buf-end sz)]
           (when (> (.read-pos buf-pos) abs-buf-end)
-            (free-storage b buf-pos)
+            (free-storage b closed? buf-pos)
             (recur (next bufs) abs-buf-end)))))))
 
 (defn segmented-buffer
@@ -302,20 +302,21 @@
        :else
        (let [buffer (:buffer state)
              buf-pos (:buf-pos state)
-             closed? (:fbos-closed? @(:closed? state))
+             closed? @(:closed? state)
+             fbos-closed? (:fbos-closed? closed?)
              lock-obj (:lock-obj state)]
-         (maybe-wait-for-bytes @buf-pos closed? lock-obj)
+         (maybe-wait-for-bytes @buf-pos fbos-closed? lock-obj)
 
          (if (closed-and-fully-read? state)
            -1 ; EOF, writer may have closed (with no new bytes) while waiting
-           (let [cnt (read-bytes buffer @buf-pos dst offset len)]
+           (let [cnt (read-bytes buffer @buf-pos dst offset len)
+                 both-closed? (every? true? (vals closed?))]
              (swap! buf-pos update-in [:read-pos] + cnt)
-             (free-storage buffer @buf-pos)
+             (free-storage buffer both-closed? @buf-pos)
              cnt)))))))
 
 (defn fbis-close [this]
   (swap! (:closed? (.state this)) assoc-in [:fbis-closed?] true))
-
 
 (defn fbis-available
   [this]

--- a/test/zensight/file_buffer/core_test.clj
+++ b/test/zensight/file_buffer/core_test.clj
@@ -39,7 +39,8 @@
 (fact "Can read and write a single byte"
       (let [fb (FileBuffer. 1024 256)
             os (.getOutputStream fb)]
-        (with-open [is (.getInputStream fb)]
+        (with-open [is (.getInputStream fb)
+                    os os]
           (.write os 65) ; "A"
           (.read is) => 65)))
 
@@ -47,7 +48,8 @@
       (let [fb (FileBuffer. 1024 256)
             os (.getOutputStream fb)
             buf (byte-array 3)]
-        (with-open [is (.getInputStream fb)]
+        (with-open [is (.getInputStream fb)
+                    os os]
           (.write os (.getBytes "abc"))
           (.read is buf) => 3
           (aget buf 0) => 97
@@ -58,7 +60,8 @@
       (let [fb (FileBuffer. 1024 256)
             os (.getOutputStream fb)
             buf (byte-array 10)]
-        (with-open [is (.getInputStream fb)]
+        (with-open [is (.getInputStream fb)
+                    os os]
           (aset-byte buf 0 65)
           (aset-byte buf 1 65)
           (.write os (.getBytes "abc"))
@@ -70,7 +73,8 @@
 (fact "Reading blocks waiting for writing"
       (let [fb (FileBuffer. 1024 256)
             os (.getOutputStream fb)]
-        (with-open [is (.getInputStream fb)]
+        (with-open [is (.getInputStream fb)
+                    os os]
           (future (Thread/sleep 250)
                   (.write os 65))
           (.read is) => 65)))
@@ -82,13 +86,15 @@
         (.write os 65)
         (.read is) => 65
         (.close os)
-        (.read is) => -1))
+        (.read is) => -1
+        (.close is)))
 
 (fact "Reads can span memory segments"
       (let [fb (FileBuffer. 26 13)
             os (.getOutputStream fb)
             buf (byte-array 26)]
-        (with-open [is (.getInputStream fb)]
+        (with-open [is (.getInputStream fb)
+                    os os]
           (.write os (.getBytes "abcdefghijklmnopqrstuvwxy"))
           (.read is buf) => 25
           (.substring (String. buf) 0 25) => "abcdefghijklmnopqrstuvwxy")))
@@ -97,7 +103,8 @@
       (let [fb (FileBuffer. 13 13)
             os (.getOutputStream fb)
             buf (byte-array 26)]
-        (with-open [is (.getInputStream fb)]
+        (with-open [is (.getInputStream fb)
+                    os os]
           (.write os (.getBytes "abcdefghijklmnopqrstuvwxy")) ; 25 chars
           (.read is buf) => 25
           (.substring (String. buf) 0 25) => "abcdefghijklmnopqrstuvwxy")))


### PR DESCRIPTION
Under heavy use, we noticed our process running out of file descriptors. We need to cleanup the file resources associated with the any FileSegments when both the Input and Output streams are closed.