### PR TITLE
readme and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+sudo: false
+language: clojure
+script: lein midje

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Distributed under the MIT License. See [LICENSE][] for more details.
 
 [license]: LICENSE
 [license-image]: http://img.shields.io/badge/license-MIT-blue.svg?style=flat-square
-[clojars-url]: https://clojars.org/file-buffer
-[clojars-img]: https://img.shields.io/clojars/v/file-buffer.svg?style=flat-square
+[clojars-url]: https://clojars.org/co.zensight/file-buffer
+[clojars-img]: https://img.shields.io/clojars/v/co.zensight/file-buffer.svg?style=flat-square
 [travis-url]: http://travis-ci.org/zensight/file-buffer
 [travis-image]: http://img.shields.io/travis/zensight/file-buffer/develop.svg?style=flat-square

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
-# Overview
+# File Buffer
 
-This code implements class FileBuffer that can be written to with a java.io.OutputStream and read via a java.io.InputStream. Writes go into the tail of the buffer and reads take place at the head. The implementation ensures that reading doesn't overtake writing which preserves the blocking semantics of java.io.InputStream.
+[![Clojars][clojars-img]][clojars-url]
+[![Build Status][travis-image]][travis-url]
+
+## Overview
+
+This package implements class FileBuffer that can be written to with a java.io.OutputStream and read via a java.io.InputStream. Writes go into the tail of the buffer and reads take place at the head. The implementation ensures that reading doesn't overtake writing which preserves the blocking semantics of java.io.InputStream.
 
 ```
                          +--------------+
@@ -22,8 +27,18 @@ FileBuffer was meant to allow concurrently downloading a large amount of data an
 
 The concurrency model of this code assumes a single reader and a single writer. However, the read and write can be on separate threads, of course.
 
+## Usage
+
+Todo: a basic example
+
 ## License
 
 Copyright © 2015 Zensight, Inc.
 
-Distributed under the MIT License.
+Distributed under the MIT License. See [LICENSE][] for more details.
+
+[license]: LICENSE
+[clojars-url]: https://clojars.org/file-buffer
+[clojars-img]: https://img.shields.io/clojars/v/file-buffer.svg?style=flat-square
+[travis-url]: http://travis-ci.org/zensight/file-buffer
+[travis-image]: http://img.shields.io/travis/zensight/file-buffer/develop.svg?style=flat-square

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Clojars][clojars-img]][clojars-url]
 [![Build Status][travis-image]][travis-url]
+[![MIT License][license-image]][license]
 
 ## Overview
 
@@ -38,6 +39,7 @@ Copyright © 2015 Zensight, Inc.
 Distributed under the MIT License. See [LICENSE][] for more details.
 
 [license]: LICENSE
+[license-image]: http://img.shields.io/badge/license-MIT-blue.svg?style=flat-square
 [clojars-url]: https://clojars.org/file-buffer
 [clojars-img]: https://img.shields.io/clojars/v/file-buffer.svg?style=flat-square
 [travis-url]: http://travis-ci.org/zensight/file-buffer

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -1,3 +1,0 @@
-# Introduction to file-buffer
-
-TODO: write [great documentation](http://jacobian.org/writing/what-to-write/)


### PR DESCRIPTION
Some random weekend gold-plating: CI builds and some badges.

One thing: I'm pretty confused about versions. There seems to be two different entries on Clojars: `co.zensight/file-buffer` and `file-buffer`. `file-buffer` seems better, but we haven't been updating that. Also, why are we only releasing snapshots?
